### PR TITLE
Add IQE dashboard page with login

### DIFF
--- a/2_Dashboard_IQE.py
+++ b/2_Dashboard_IQE.py
@@ -1,0 +1,47 @@
+import os
+import pandas as pd
+import requests
+import streamlit as st
+
+from components.status_pie import status_pie
+from components.responsavel_bar import responsavel_bar
+from components.monthly_activity_bar import monthly_activity_bar
+from components.prioridade_hist import prioridade_hist
+from components.avg_completion_time_bar import avg_completion_time_bar
+from components.temporal_area import temporal_area
+
+st.set_page_config(page_title="Dashboard IQE", page_icon="📈", layout="wide")
+
+if "authenticated" not in st.session_state:
+    st.session_state["authenticated"] = False
+
+if not st.session_state["authenticated"]:
+    st.warning("Faça o login para acessar o dashboard.")
+    st.stop()
+
+st.title("Dashboard IQE")
+
+@st.cache_data(show_spinner=False)
+def load_data():
+    base_url = os.environ.get("API_BASE_URL", st.secrets.get("API_BASE_URL", "http://10.19.10.65:8105"))
+    token = st.session_state.get("token", "")
+    url = f"{base_url}/api/v1/iqe-data/"
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return pd.DataFrame(resp.json())
+    except Exception as e:
+        st.info("Não foi possível obter dados da API, usando arquivo local.")
+        return pd.read_csv("TABLE_EXPORT_DATA.csv")
+
+df = load_data()
+
+status_pie(df)
+responsavel_bar(df)
+monthly_activity_bar(df)
+prioridade_hist(df)
+avg_completion_time_bar(df)
+temporal_area(df)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ pip install -r requirements.txt
 streamlit run 2_Dashboard_IQE.py
 ```
 
+Ao abrir o aplicativo utilize a opção **Login** da barra lateral para se autenticar. O dashboard só é exibido para usuários logados.
+
 ## Estrutura do projeto
 
 - `app.py` &mdash; aplicação principal do Streamlit.
+- `2_Dashboard_IQE.py` &mdash; página do dashboard IQE (requer login).
 - `components/` &mdash; módulos contendo cada gráfico do dashboard.
 - `assets/logo/` &mdash; pasta reservada para a logo da Pneubras.
 - `TABLE_EXPORT_DATA.csv` &mdash; base de dados utilizada pelo dashboard.


### PR DESCRIPTION
## Summary
- require authentication in new `2_Dashboard_IQE.py`
- show fallback to local CSV when API fails
- document that login is required for the dashboard

## Testing
- `python -m py_compile 2_Dashboard_IQE.py pages/1_login.py app.py components/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685d5df160cc83338c1ef980c129742e