### PR TITLE
Fix DataFrame column casing to avoid KeyError

### DIFF
--- a/config/db_connection.py
+++ b/config/db_connection.py
@@ -37,6 +37,10 @@ def run_query(start_date: datetime, end_date: datetime) -> pd.DataFrame:
 
             df = pd.read_sql(query, conn, params=params)
 
+            # Padroniza os nomes das colunas para maiúsculo para evitar erros
+            # de chave quando diferentes bancos retornam casing distinto
+            df.columns = [col.upper() for col in df.columns]
+
             def convert_lob_to_str(val):
                 if hasattr(val, 'read'): return val.read()
                 return val


### PR DESCRIPTION
## Summary
- ensure `run_query` uppercases returned column names

## Testing
- `pytest -q`
- `python -m py_compile config/db_connection.py pages/2_Dashboard_IQE.py components/*.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_685dad6bf50c8333858180f84f2f33cc