### PR TITLE
Update charts with neutral color palette

### DIFF
--- a/components/avg_completion_time_bar.py
+++ b/components/avg_completion_time_bar.py
@@ -43,7 +43,7 @@ def avg_completion_time_bar(df: pd.DataFrame):
         y=avg_time.index,
         x=avg_time.values,
         orientation='h',
-        marker_color='#FF8C00'
+        marker_color='#9575CD'
     ))
 
     fig.update_layout(

--- a/components/monthly_activity_bar.py
+++ b/components/monthly_activity_bar.py
@@ -38,7 +38,13 @@ def monthly_activity_bar(df: pd.DataFrame):
 
     monthly_activity_counts.sort_values(by='MES_ANO_ORDEM', inplace=True)
 
-    cores_quentes = ['#d32f2f', '#ff7043', '#ffa726', '#ffca28', '#ffeb3b']
+    color_map = {
+        'bug': '#EF9A9A',
+        'criação': '#64B5F6',
+        'melhorias': '#4CAF50',
+        'atualizações de versão': '#9575CD',
+        'input via banco': '#FFF176'
+    }
 
     fig = px.bar(
         monthly_activity_counts,
@@ -49,7 +55,7 @@ def monthly_activity_bar(df: pd.DataFrame):
         labels={'MES_ANO_LABEL': 'Mês de Criação', 'count': 'Quantidade de Tarefas',
                 coluna_tipo: 'Tipo de Solicitação'},
         barmode='group',
-        color_discrete_sequence=cores_quentes
+        color_discrete_map=color_map
     )
 
     fig.update_layout(

--- a/components/prioridade_hist.py
+++ b/components/prioridade_hist.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import plotly.graph_objects as go
+import plotly.express as px
 
 
 def prioridade_hist(df: pd.DataFrame):
@@ -15,13 +16,21 @@ def prioridade_hist(df: pd.DataFrame):
                      font=dict(size=16))]
         )
     else:
-        fig.add_trace(go.Histogram(
-            x=df['PRIORIDADE'].dropna(),
-            name='Prioridade',
-            marker_color='#FFA500'
-        ))
+        color_map = {
+            'nenhuma': '#CFD8DC',
+            'high': '#FFF176',
+            'urgente': '#FF9800',
+            'normal': '#90CAF9'
+        }
+
+        fig = px.histogram(
+            df.dropna(subset=['PRIORIDADE']),
+            x='PRIORIDADE',
+            color='PRIORIDADE',
+            color_discrete_map=color_map,
+            title='Distribuição de Prioridade das Tarefas'
+        )
         fig.update_layout(
-            title_text='Distribuição de Prioridade das Tarefas',
             xaxis_title='Prioridade',
             yaxis_title='Contagem'
         )

--- a/components/responsavel_bar.py
+++ b/components/responsavel_bar.py
@@ -28,7 +28,7 @@ def responsavel_bar(df: pd.DataFrame):
             y=responsavel_counts.index,
             x=responsavel_counts.values,
             orientation='h',
-            marker_color='#FF6347'
+            marker_color='#4DB6AC'
         ))
         fig.update_layout(
             title_text='Top 10 Responsáveis por Tarefas (Contagem Individual)',

--- a/components/status_pie.py
+++ b/components/status_pie.py
@@ -16,13 +16,23 @@ def status_pie(df: pd.DataFrame):
         )
     else:
         status_counts = df['STATUS'].value_counts()
-        cores_quentes = ['#d32f2f', '#ff7043', '#ffa726', '#ffca28', '#ffeb3b']
+
+        color_map = {
+            'complete': '#4CAF50',           # concluído
+            'backlog': '#BDBDBD',            # backlog
+            'em andamento': '#90CAF9',       # em andamento
+            'em validação': '#1565C0',   # em validação
+            'dependência de terceiros': '#9575CD'
+        }
+
+        colors = [color_map.get(str(status).lower(), '#BDBDBD')
+                  for status in status_counts.index]
 
         fig.add_trace(go.Pie(
             labels=status_counts.index,
             values=status_counts.values,
             hole=.3,
-            marker=dict(colors=cores_quentes, line=dict(color='#ffffff', width=2))
+            marker=dict(colors=colors, line=dict(color='#ffffff', width=2))
         ))
         fig.update_layout(
             title_text='Distribuição de Status das Tarefas',

--- a/components/temporal_area.py
+++ b/components/temporal_area.py
@@ -25,7 +25,7 @@ def temporal_area(df: pd.DataFrame):
         y='count',
         title='Volume de Tarefas Criadas por Dia',
         labels={'DATA_DIA': 'Data', 'count': 'Número de Tarefas Criadas'},
-        color_discrete_sequence=['#FF7F50']
+        color_discrete_sequence=['rgba(66, 165, 245, 0.4)']
     )
 
     return fig


### PR DESCRIPTION
## Summary
- use neutral colors for status pie chart
- soften bar chart colors for responsible ranking
- apply lighter shades on priority histogram
- adjust monthly activity bar palette
- tone down temporal area and completion time bars

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685daf1b701483338fafd3ec5c010a72